### PR TITLE
[Feat] Auth 파트 API 초기 구조 세팅

### DIFF
--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -1,0 +1,73 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { AuthController } from './auth.controller';
+
+describe('AuthController', () => {
+  let controller: AuthController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AuthController],
+    }).compile();
+
+    controller = module.get<AuthController>(AuthController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('should return kakao register message', () => {
+    expect(controller.registerKakao()).toEqual({
+      message: '카카오 회원가입 (POST /auth/register/kakao)',
+    });
+  });
+
+  it('should return terms message', () => {
+    expect(controller.getTerms()).toEqual({
+      message: '회원가입 시 약관 조회 (GET /auth/terms)',
+    });
+  });
+
+  it('should return kakao login message', () => {
+    expect(controller.loginKakao()).toEqual({
+      message: '카카오 로그인 (GET /auth/login/kakao)',
+    });
+  });
+
+  it('should return kakao callback message', () => {
+    expect(controller.kakaoLoginCallback()).toEqual({
+      message: '카카오 로그인 Callback (GET /auth/login/kakao/callback)',
+    });
+  });
+
+  it('should return logout message', () => {
+    expect(controller.logout()).toEqual({
+      message: '로그아웃 (DELETE /auth/logout)',
+    });
+  });
+
+  it('should return token reissue message', () => {
+    expect(controller.reissueToken()).toEqual({
+      message: 'RT 이용한 AT 재발급 (GET /auth/token/reissue)',
+    });
+  });
+
+  it('should return phone send message', () => {
+    expect(controller.sendPhoneCode()).toEqual({
+      message: '휴대폰 인증번호 발송 (POST /auth/phone/send)',
+    });
+  });
+
+  it('should return phone verify message', () => {
+    expect(controller.verifyPhoneCode()).toEqual({
+      message: '휴대폰 인증번호 확인 (POST /auth/phone/verify)',
+    });
+  });
+
+  it('should return phone status message', () => {
+    expect(controller.phoneStatus()).toEqual({
+      message: '전화번호 인증 상태 확인 (GET /auth/phone/status)',
+    });
+  });
+});

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,0 +1,58 @@
+import { Controller, Delete, Get, Post } from '@nestjs/common';
+
+@Controller('auth')
+export class AuthController {
+  // 카카오 회원가입
+  @Post('register/kakao')
+  registerKakao() {
+    return { message: '카카오 회원가입 (POST /auth/register/kakao)' };
+  }
+
+  // 회원가입 시 약관 조회
+  @Get('terms')
+  getTerms() {
+    return { message: '회원가입 시 약관 조회 (GET /auth/terms)' };
+  }
+
+  // 카카오 로그인
+  @Get('login/kakao')
+  loginKakao() {
+    return { message: '카카오 로그인 (GET /auth/login/kakao)' };
+  }
+
+  // 카카오 로그인 Callback
+  @Get('login/kakao/callback')
+  kakaoLoginCallback() {
+    return { message: '카카오 로그인 Callback (GET /auth/login/kakao/callback)' };
+  }
+
+  // 로그아웃
+  @Delete('logout')
+  logout() {
+    return { message: '로그아웃 (DELETE /auth/logout)' };
+  }
+
+  // RT 이용한 Access Token 재발급
+  @Get('token/reissue')
+  reissueToken() {
+    return { message: 'RT 이용한 AT 재발급 (GET /auth/token/reissue)' };
+  }
+
+  // 휴대폰 인증번호 발송
+  @Post('phone/send')
+  sendPhoneCode() {
+    return { message: '휴대폰 인증번호 발송 (POST /auth/phone/send)' };
+  }
+
+  // 휴대폰 인증번호 확인
+  @Post('phone/verify')
+  verifyPhoneCode() {
+    return { message: '휴대폰 인증번호 확인 (POST /auth/phone/verify)' };
+  }
+
+  // 휴대폰 인증 상태 확인
+  @Get('phone/status')
+  phoneStatus() {
+    return { message: '전화번호 인증 상태 확인 (GET /auth/phone/status)' };
+  }
+}

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+
+import { AuthController } from './auth.controller';
+
+@Module({
+  controllers: [AuthController],
+})
+export class AuthModule {}


### PR DESCRIPTION
## #️⃣ Related Issues

> 연관된 모든 Issue를 작성해주세요.


## 🧑‍💻 작업 내용

> 어떤 작업을 진행했는지 자세하게 작성해주세요.

- 초기 의존성 설치 (npm install)
- AuthController 및 AuthModule 생성
- 다음 인증 API 9개 깡통 핸들러 구성:
  - POST /auth/register/kakao: 카카오 회원가입
  - GET /auth/terms: 회원가입 시 약관 조회
  - GET /auth/login/kakao: 카카오 로그인
  - GET /auth/login/kakao/callback: 카카오 로그인 Callback
  - DELETE /auth/logout: 로그아웃
  - GET /auth/token/reissue: RT 이용한 AT 재발급
  - POST /auth/phone/send: 휴대폰 인증번호 발송
  - POST /auth/phone/verify: 휴대폰 인증번호 확인
  - GET /auth/phone/status: 전화번호 인증 상태 조회

## 💾 작업 결과 (선택)

> 사진, 영상 등을 첨부해주세요.



## 💬 리뷰 시 요청사항 (선택)

> Reviewer는 코드 리뷰의 코멘트에 코멘트를 강조하고 싶은 정도를 [Pn 규칙](https://blog.banksalad.com/tech/banksalad-code-review-culture/#%EC%BB%A4%EB%AE%A4%EB%8B%88%EC%BC%80%EC%9D%B4%EC%85%98-%EB%B9%84%EC%9A%A9%EC%9D%84-%EC%A4%84%EC%9D%B4%EA%B8%B0-%EC%9C%84%ED%95%9C-pn-%EB%A3%B0)에
> 맞춰서 표기해 주세요.



## 📝 Checklist

- [x] Reviewer를 추가했나요?
- [x] Convention을 준수했나요?
