### PR TITLE
[Fix] 이벤트 찜/찜 해제 API 예외 처리 추가

### DIFF
--- a/src/modules/events/services/events.scrap.command.service.ts
+++ b/src/modules/events/services/events.scrap.command.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
 
 import { PrismaService } from '@modules/prisma/prisma.service';
 
@@ -11,6 +11,12 @@ export class EventsScrapService {
     const event = await this.prisma.event.findUnique({ where: { id: eventId } });
     if (!event) throw new NotFoundException('Event not found');
 
+    // 이미 찜했는지 확인
+    const existing = await this.prisma.eventScrap.findUnique({
+      where: { userId_eventId: { userId, eventId } },
+    });
+    if (existing) throw new ConflictException('이미 찜한 이벤트입니다.');
+
     await this.prisma.eventScrap.create({
       data: { userId, eventId },
     });
@@ -22,6 +28,12 @@ export class EventsScrapService {
     // 이벤트 존재 여부 확인
     const event = await this.prisma.event.findUnique({ where: { id: eventId } });
     if (!event) throw new NotFoundException('Event not found');
+
+    // 찜 기록이 없으면 에러
+    const existing = await this.prisma.eventScrap.findUnique({
+      where: { userId_eventId: { userId, eventId } },
+    });
+    if (!existing) throw new NotFoundException('찜하지 않은 이벤트입니다.');
 
     await this.prisma.eventScrap.delete({
       where: { userId_eventId: { userId, eventId } },


### PR DESCRIPTION
## #️⃣ Related Issues

> 연관된 모든 Issue를 작성해주세요.  
> closes 나 resolves prefix를 붙여서 자동으로 Issue가 Close 될 수 있도록 해주세요.

- resolves #60, #82 

## 🧑‍💻 작업 내용 및 결과

> 어떤 작업을 진행했는지 자세하게 작성해주세요.  
> 사진을 첨부하셔도 좋습니다.

- 이벤트 찜/찜 해제 API 예외 처리 추가
  - 존재하지 않는 이벤트 → NotFoundException 반환
  - 이미 찜한 이벤트 재요청(POST /events/:id/scrap) → ConflictException 반환
  - 찜하지 않은 이벤트 해제 요청(DELETE /events/:id/scrap) → NotFoundException 반환

## 💬 리뷰 시 요청사항 (선택)

> Reviewer는 코드 리뷰의 코멘트에 코멘트를 강조하고 싶은 정도를 [Pn 규칙](https://blog.banksalad.com/tech/banksalad-code-review-culture/#%EC%BB%A4%EB%AE%A4%EB%8B%88%EC%BC%80%EC%9D%B4%EC%85%98-%EB%B9%84%EC%9A%A9%EC%9D%84-%EC%A4%84%EC%9D%B4%EA%B8%B0-%EC%9C%84%ED%95%9C-pn-%EB%A3%B0)에
> 맞춰서 표기해 주세요.


## 📝 Checklist

- [x] Reviewer를 추가했나요?
- [x] Convention을 준수했나요?
