### PR TITLE
[Refactor] user 파트 userId 하드코딩 제거

### DIFF
--- a/src/common/decorators/user-id-decorator.ts
+++ b/src/common/decorators/user-id-decorator.ts
@@ -1,25 +1,27 @@
-import { BadRequestException, ExecutionContext, createParamDecorator } from '@nestjs/common';
+import {
+  BadRequestException,
+  ExecutionContext,
+  UnauthorizedException,
+  createParamDecorator,
+} from '@nestjs/common';
 
 /**
  * @UserId()
  * - 컨트롤러 파라미터에 userId(bigint)를 자동 주입하는 커스텀 데코레이터
- * - 현재는 헤더 `x-mock-user-id` 값을 BigInt로 변환하여 반환
- * - 추후 Auth 파트 하면서 JWT 인증 도입 시 req.user.id로 교체 예정
+ * - JWT 인증 완료 후, req.user.userId 값을 BigInt로 변환하여 반환
  */
-export const UserId = createParamDecorator(
-  (_: unknown, executionContext: ExecutionContext): bigint => {
-    // 현재 실행 컨텍스트에서 HTTP 요청 객체 추출
-    const req = executionContext.switchToHttp().getRequest();
+export const UserId = createParamDecorator((_: unknown, context: ExecutionContext): bigint => {
+  const req = context.switchToHttp().getRequest();
 
-    const rawUserId = req.headers['x-mock-user-id'] as string | undefined;
+  const userId = req.user?.userId;
 
-    // 헤더가 없을 경우: 일단 기본값 BigInt 1을 반환하도록 설정, 추후에는 UnauthorizedException으로 처리할 듯
-    if (!rawUserId) return 1n;
+  if (!userId) {
+    throw new UnauthorizedException('사용자 인증이 필요합니다.');
+  }
 
-    try {
-      return BigInt(rawUserId); // 문자열을 BigInt로 변환
-    } catch {
-      throw new BadRequestException('유효하지 않은 사용자 ID 헤더입니다.');
-    }
-  },
-);
+  try {
+    return BigInt(userId);
+  } catch {
+    throw new BadRequestException('유효하지 않은 사용자 ID입니다.');
+  }
+});

--- a/src/modules/users/dto/profile.dto.ts
+++ b/src/modules/users/dto/profile.dto.ts
@@ -8,6 +8,8 @@ export class UpdateProfileImageRequestDto {
     description: '새 프로필 이미지 URL. null이면 삭제로 처리',
     required: false,
     nullable: true,
+    type: String,
+    example: 'https://cdn.peekle.kr/profile/example.png',
   })
   @Transform(({ value }) => (value === null ? null : value))
   @IsOptional() // undefined는 검증 제외

--- a/src/modules/users/dto/terms.dto.ts
+++ b/src/modules/users/dto/terms.dto.ts
@@ -25,9 +25,7 @@ export class TermsHistoryItemDto {
   @ApiProperty({
     description: '약관 ID',
   })
-  @IsBigInt()
-  @TransformToBigint()
-  termId!: bigint;
+  termId!: string;
 
   @ApiProperty({
     description: '약관 제목',

--- a/src/modules/users/services/users.service.ts
+++ b/src/modules/users/services/users.service.ts
@@ -82,7 +82,7 @@ export class UsersService {
 
     return {
       items: terms.map((term) => ({
-        termId: term.id,
+        termId: term.id.toString(),
         title: term.title,
         isRequired: term.isRequired,
         isAccepted: term.userTerm[0]?.isAccepted ?? false,

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -1,8 +1,8 @@
-import { Body, Controller, Get, Patch, Query } from '@nestjs/common';
+import { Body, Controller, Get, Patch, Query, Req } from '@nestjs/common';
 import { ApiBearerAuth, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 
-// 임시 유저 식별 (JWT 붙기 전까지 mock 헤더 사용)
-import { UserId } from '@common/decorators/user-id-decorator';
+// req.user?.userId로 꺼내오도록 하긴 했는데 다른 파트와의 코드 일관성을 위해 일단 사용하진 않음
+// import { UserId } from '@common/decorators/user-id-decorator';
 
 import { Public } from '@modules/auth/decorators/public.decorator';
 import { GetMeResponseDto } from '@modules/users/dto/get-me.dto';
@@ -30,55 +30,64 @@ import { UsersService } from '@modules/users/services/users.service';
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
-  @ApiOperation({ summary: '내 정보 조회' })
-  @ApiOkResponse({ type: GetMeResponseDto })
   @ApiBearerAuth()
   @Get('me')
-  getUserInfo(@UserId() userId: bigint): Promise<GetMeResponseDto> {
+  @ApiOperation({ summary: '내 정보 조회' })
+  @ApiOkResponse({ type: GetMeResponseDto })
+  getUserInfo(@Req() req: any): Promise<GetMeResponseDto> {
+    const userId = req.user?.userId;
     return this.usersService.getUserInfo(userId);
   }
 
-  @ApiOperation({ summary: '닉네임 사용 가능 여부 확인(디바운스용)' })
-  @ApiOkResponse({ type: CheckNicknameResponseDto })
   @Public()
   @Get('nickname/check')
+  @ApiOperation({ summary: '닉네임 사용 가능 여부 확인(디바운스용)' })
+  @ApiOkResponse({ type: CheckNicknameResponseDto })
   checkNickname(@Query() q: CheckNicknameQueryDto): Promise<CheckNicknameResponseDto> {
     return this.usersService.checkNicknameAvailability(q.nickname);
   }
 
+  @ApiBearerAuth()
+  @Patch('me/nickname')
   @ApiOperation({ summary: '내 정보 - 닉네임 수정' })
   @ApiOkResponse({ type: UpdateNicknameResponseDto })
-  @Patch('me/nickname')
   updateNickname(
-    @UserId() userId: bigint,
+    @Req() req: any,
     @Body() body: UpdateNicknameRequestDto,
   ): Promise<UpdateNicknameResponseDto> {
+    const userId = req.user?.userId;
     return this.usersService.updateNickname(userId, body);
   }
 
+  @ApiBearerAuth()
+  @Patch('me/profile-image')
   @ApiOperation({ summary: '내 정보 - 프로필 이미지 수정/삭제' })
   @ApiOkResponse({ type: UpdateProfileImageResponseDto })
-  @Patch('me/profile-image')
   updateProfileImage(
-    @UserId() userId: bigint,
+    @Req() req: any,
     @Body() body: UpdateProfileImageRequestDto,
   ): Promise<UpdateProfileImageResponseDto> {
+    const userId = req.user?.userId;
     return this.usersService.updateProfileImage(userId, body);
   }
 
+  @ApiBearerAuth()
+  @Get('terms')
   @ApiOperation({ summary: '사용자의 약관 동의 내역 조회' })
   @ApiOkResponse({ type: GetTermsHistoryResponseDto })
-  @Get('terms')
-  getTermsHistory(@UserId() userId: bigint): Promise<GetTermsHistoryResponseDto> {
+  getTermsHistory(@Req() req: any): Promise<GetTermsHistoryResponseDto> {
+    const userId = req.user?.userId;
     return this.usersService.getTermsHistory(userId);
   }
 
+  @ApiBearerAuth()
+  @Patch('terms')
   @ApiOperation({ summary: '사용자의 약관 동의 내역 수정' })
   @ApiOkResponse({
     schema: { example: { message: '약관 동의 내역이 업데이트되었습니다.' } },
   })
-  @Patch('terms')
-  updateTermsAgreement(@UserId() userId: bigint, @Body() body: UpdateTermsAgreementRequestDto) {
+  updateTermsAgreement(@Req() req: any, @Body() body: UpdateTermsAgreementRequestDto) {
+    const userId = req.user?.userId;
     return this.usersService.updateTermsAgreement(userId, body);
   }
 }


### PR DESCRIPTION
## #️⃣ Related Issues

> 연관된 모든 Issue를 작성해주세요.  
> closes 나 resolves prefix를 붙여서 자동으로 Issue가 Close 될 수 있도록 해주세요.

- resolves #100 

## 🧑‍💻 작업 내용 및 결과

> 어떤 작업을 진행했는지 자세하게 작성해주세요.  
> 사진을 첨부하셔도 좋습니다.

- UsersController 전 구간에서 @UserId() 제거 → req.user.userId 직접 사용
- 인증 필요한 엔드포인트에 @ApiBearerAuth() 추가
-  BigInt 직렬화 오류 해결
   - TermsHistoryItemDto.termId 타입을 bigint → string 으로 변경
   - users.service.ts 약관 조회 응답에서 term.id.toString() 적용

## 💬 리뷰 시 요청사항 (선택)

> Reviewer는 코드 리뷰의 코멘트에 코멘트를 강조하고 싶은 정도를 [Pn 규칙](https://blog.banksalad.com/tech/banksalad-code-review-culture/#%EC%BB%A4%EB%AE%A4%EB%8B%88%EC%BC%80%EC%9D%B4%EC%85%98-%EB%B9%84%EC%9A%A9%EC%9D%84-%EC%A4%84%EC%9D%B4%EA%B8%B0-%EC%9C%84%ED%95%9C-pn-%EB%A3%B0)에
> 맞춰서 표기해 주세요.


## 📝 Checklist

- [x] Reviewer를 추가했나요?
- [x] Convention을 준수했나요?
