### PR TITLE
[Refactor] 이벤트 상세 정보에 찜 여부 포함

### DIFF
--- a/src/modules/events/controllers/events.v1.controller.ts
+++ b/src/modules/events/controllers/events.v1.controller.ts
@@ -70,13 +70,15 @@ export class EventsController {
     return { events, nextCursor, hasNextPage };
   }
 
+  @ApiBearerAuth()
   @Public()
   @Get(':id')
   @ApiOperation({ summary: '이벤트 상세 조회 API' })
   @ApiOkResponse({ type: GetEventDetailResponseDto })
   @ResponseMessage('이벤트 상세 내용을 조회했습니다.')
-  async detail(@Param() { id }: GetEventDetailParamsDto) {
-    const event = await this.eventsQuery.getEventDetail(id);
+  async detail(@Param() { id }: GetEventDetailParamsDto, @Req() req: any) {
+    const userId: bigint = req.user?.userId;
+    const event = await this.eventsQuery.getEventDetail(id, userId);
     return { event };
   }
 

--- a/src/modules/events/dto/get-event-detail.dto.ts
+++ b/src/modules/events/dto/get-event-detail.dto.ts
@@ -118,4 +118,10 @@ export class GetEventDetailResponseDto {
 
   @ApiProperty({ description: '경도', example: 126.9754, nullable: true })
   longitude?: number | null;
+
+  @ApiProperty({
+    description: '현재 로그인한 사용자가 이 이벤트를 찜했는지 여부',
+    example: false,
+  })
+  isScrapped!: boolean;
 }

--- a/src/modules/events/services/events.query.service.ts
+++ b/src/modules/events/services/events.query.service.ts
@@ -323,7 +323,7 @@ export class EventsQueryService {
     return { events, nextCursor, nextCursorDistance, hasNextPage };
   }
 
-  async getEventDetail(id: bigint): Promise<GetEventDetailResponseDto> {
+  async getEventDetail(id: bigint, userId?: bigint): Promise<GetEventDetailResponseDto> {
     const event = await this.prisma.event.findUnique({
       where: { id },
       include: {
@@ -336,6 +336,12 @@ export class EventsQueryService {
 
     if (!event) {
       throw new NotFoundException('해당 이벤트를 찾을 수 없습니다.');
+    }
+
+    let isScrapped = false;
+    if (userId) {
+      const scrap = await this.prisma.eventScrap.findFirst({ where: { eventId: id, userId } });
+      isScrapped = !!scrap; // scrap이 존재하면 true, 없으면 false로 저장
     }
 
     return {
@@ -360,6 +366,7 @@ export class EventsQueryService {
         imageUrl: process.env.CLOUDFRONT_URL + img.imageUrl, // TODO: 이미지 URL 저장 방식에 따라 수정이 필요(할 수도 있고 안 할 수도 있습니다)
         order: img.order,
       })),
+      isScrapped,
     };
   }
 }


### PR DESCRIPTION
## #️⃣ Related Issues

> 연관된 모든 Issue를 작성해주세요.  
> closes 나 resolves prefix를 붙여서 자동으로 Issue가 Close 될 수 있도록 해주세요.

- resolves #115 

## 🧑‍💻 작업 내용 및 결과

> 어떤 작업을 진행했는지 자세하게 작성해주세요.  
> 사진을 첨부하셔도 좋습니다.

- 이벤트 상세 조회 API가 사용자 찜 여부 나타내도록 수정
  - GetEventDetailResponseDto에 isScrapped 필드 추가
  - EventsQueryService에서 로그인 사용자 기준 찜 여부 확인 로직 추가
  - 이벤트 상세 조회 컨트롤러에서 userId를 전달하도록 수정
  - 로그인 여부와 무관하게 상세 조회 가능 (비로그인 시 기본값 false)


## 📝 Checklist

- [x] Reviewer를 추가했나요?
- [x] Convention을 준수했나요?
