### PR TITLE
(재등록) [Feat] 내 정보 조회 및 수정 API 구현

### DIFF
--- a/src/common/decorators/user-id-decorator.ts
+++ b/src/common/decorators/user-id-decorator.ts
@@ -1,0 +1,25 @@
+import { BadRequestException, ExecutionContext, createParamDecorator } from '@nestjs/common';
+
+/**
+ * @UserId()
+ * - 컨트롤러 파라미터에 userId(bigint)를 자동 주입하는 커스텀 데코레이터
+ * - 현재는 헤더 `x-mock-user-id` 값을 BigInt로 변환하여 반환
+ * - 추후 Auth 파트 하면서 JWT 인증 도입 시 req.user.id로 교체 예정
+ */
+export const UserId = createParamDecorator(
+  (_: unknown, executionContext: ExecutionContext): bigint => {
+    // 현재 실행 컨텍스트에서 HTTP 요청 객체 추출
+    const req = executionContext.switchToHttp().getRequest();
+
+    const rawUserId = req.headers['x-mock-user-id'] as string | undefined;
+
+    // 헤더가 없을 경우: 일단 기본값 BigInt 1을 반환하도록 설정, 추후에는 UnauthorizedException으로 처리할 듯
+    if (!rawUserId) return 1n;
+
+    try {
+      return BigInt(rawUserId); // 문자열을 BigInt로 변환
+    } catch {
+      throw new BadRequestException('유효하지 않은 사용자 ID 헤더입니다.');
+    }
+  },
+);

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -15,6 +15,6 @@ export class AuthController {
   @Post('register')
   async register(@Body() user: CreateUserRequestDto) {
     console.log(user);
-    return this.usersService.createNewUser(user);
+    return this.usersService.createUser(user);
   }
 }

--- a/src/modules/users/dto/create-user.ts
+++ b/src/modules/users/dto/create-user.ts
@@ -3,6 +3,14 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { IsDate, IsNotEmpty, IsString } from 'class-validator';
 
+/**
+ * CreateUserRequestDto (Request DTO)
+ * - 클라이언트 → 서버 요청을 받을 때 사용
+ * - 사용자가 보내는 JSON 바디를 런타임에서 유효성 검사해야 함
+ * - 따라서 @IsString(), @IsDateString(), @IsNotEmpty() 같은 데코레이터를 붙여서
+ *   들어오는 값이 의도한 타입/형식인지 검증하는 게 필수
+ */
+
 export class CreateUserRequestDto {
   @IsString()
   @IsNotEmpty()

--- a/src/modules/users/dto/get-me.ts
+++ b/src/modules/users/dto/get-me.ts
@@ -1,0 +1,68 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * GetMeResponseDto (Response DTO)
+ * - 서버 → 클라이언트 응답을 내보낼 때 사용
+ * - 이 값들은 이미 서버(우리 코드)에서 DB → 서비스 → DTO 변환을 거쳐 나온 값이므로,
+ *   다시 유효성 검증을 할 필요가 없어서 @IsString(), 등으로 검증하지 않음
+ */
+
+export class GetMeResponseDto {
+  @ApiProperty({
+    description: '사용자 ID (서버 → 클라이언트: JSON은 BigInt 그대로 직렬화 불가해서 string으로)',
+  })
+  id!: string;
+
+  @ApiProperty({
+    description: '사용자 이름',
+  })
+  name!: string;
+
+  @ApiProperty({
+    description: '사용자 닉네임',
+  })
+  nickname!: string;
+
+  @ApiProperty({
+    description: '사용자 생년월일 (DB DATE → YYYY-MM-DD 문자열)',
+    format: 'date',
+  })
+  birthdate!: string;
+
+  @ApiProperty({
+    description: '사용자 성별',
+    required: false,
+  })
+  gender?: string;
+
+  @ApiProperty({
+    description: '사용자 전화번호',
+    required: false,
+  })
+  phoneNumber?: string;
+
+  @ApiProperty({
+    description: '사용자 프로필 이미지 URL',
+    required: false,
+  })
+  profileImage?: string;
+
+  @ApiProperty({
+    description: '사용자 역할 (예: admin, user)',
+  })
+  role!: string;
+
+  @ApiProperty({
+    description: '계정 생성 일시 (DB TIMESTAMP(6) → ISO8601 문자열)',
+    format: 'date-time',
+    example: '2025-08-21T04:12:33.123Z',
+  })
+  createdAt!: string;
+
+  @ApiProperty({
+    description: '계정 수정 일시 (DB TIMESTAMP(6) → ISO8601 문자열)',
+    format: 'date-time',
+    example: '2025-08-21T05:10:01.987Z',
+  })
+  updatedAt!: string;
+}

--- a/src/modules/users/dto/nickname.ts
+++ b/src/modules/users/dto/nickname.ts
@@ -1,0 +1,45 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { Transform } from 'class-transformer';
+import { IsString, Length, Matches } from 'class-validator';
+
+// 허용 문자 셋: 숫자, 영문 대/소, 한글 자모(3131~318E) + 완성형(AC00~D7A3), 공백
+const NICKNAME_CHARSET = /^[0-9A-Za-z\u3131-\u318E\uAC00-\uD7A3 ]+$/;
+
+export class CheckNicknameQueryDto {
+  @ApiProperty({
+    description: '중복 확인할 닉네임 (앞/뒤 공백은 자동 제거, 중간 공백 허용, 1~10자)',
+    maxLength: 10,
+  })
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value)) 
+  @IsString()
+  @Length(1, 10)
+  @Matches(NICKNAME_CHARSET, {
+    message: '닉네임은 한글(자모/완성형), 영문, 숫자, 공백만 사용할 수 있습니다.',
+  })
+  nickname!: string;
+}
+
+export class CheckNicknameResponseDto {
+  @ApiProperty({ description: '사용 가능 여부', example: true })
+  available!: boolean;
+}
+
+export class UpdateNicknameRequestDto {
+  @ApiProperty({
+    description: '변경할 닉네임 (앞/뒤 공백은 자동 제거, 중간 공백 허용, 1~10자)',
+    maxLength: 10,
+  })
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  @IsString()
+  @Length(1, 10)
+  @Matches(NICKNAME_CHARSET, {
+    message: '닉네임은 한글(자모/완성형), 영문, 숫자, 공백만 사용할 수 있습니다.',
+  })
+  nickname!: string;
+}
+
+export class UpdateNicknameResponseDto {
+  @ApiProperty({ example: '닉네임이 변경되었습니다.' })
+  message!: string;
+}

--- a/src/modules/users/dto/profile.ts
+++ b/src/modules/users/dto/profile.ts
@@ -1,13 +1,15 @@
 import { ApiProperty } from '@nestjs/swagger';
 
+import { Transform } from 'class-transformer';
 import { IsOptional, IsString, IsUrl } from 'class-validator';
 
 export class UpdateProfileImageRequestDto {
   @ApiProperty({
-    description: '새 프로필 이미지 URL. null/빈 문자열이면 삭제로 처리',
+    description: '새 프로필 이미지 URL. null이면 삭제로 처리',
     required: false,
     nullable: true,
   })
+  @Transform(({ value }) => (value === null ? null : value))
   @IsOptional() // undefined는 검증 제외
   @IsString()
   @IsUrl({}, { message: '유효한 URL이어야 합니다.' })

--- a/src/modules/users/dto/profile.ts
+++ b/src/modules/users/dto/profile.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { IsOptional, IsString, IsUrl } from 'class-validator';
+
+export class UpdateProfileImageRequestDto {
+  @ApiProperty({
+    description: '새 프로필 이미지 URL. null/빈 문자열이면 삭제로 처리',
+    required: false,
+    nullable: true,
+  })
+  @IsOptional() // undefined는 검증 제외
+  @IsString()
+  @IsUrl({}, { message: '유효한 URL이어야 합니다.' })
+  profileImage?: string | null;
+}
+
+export class UpdateProfileImageResponseDto {
+  @ApiProperty({ example: '프로필 이미지가 업데이트되었습니다.' })
+  message!: string;
+}

--- a/src/modules/users/dto/terms.ts
+++ b/src/modules/users/dto/terms.ts
@@ -1,0 +1,61 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { Type } from 'class-transformer';
+import { IsArray, IsBoolean, IsNumber, ValidateNested } from 'class-validator';
+
+export class TermsHistoryItemDto {
+  @ApiProperty({
+    description: '약관 ID (서버 → 클라이언트: JSON은 BigInt 그대로 직렬화 불가해서 string으로)',
+  })
+  termId!: string;
+
+  @ApiProperty({
+    description: '약관 제목',
+  })
+  title!: string;
+
+  @ApiProperty({
+    description: '필수 약관 여부',
+  })
+  isRequired!: boolean;
+
+  @ApiProperty({
+    description: '사용자가 해당 약관에 동의했는지 여부',
+  })
+  isAccepted!: boolean;
+}
+
+export class GetTermsHistoryResponseDto {
+  @ApiProperty({
+    description: '약관 동의 이력 목록',
+    type: [TermsHistoryItemDto],
+  })
+  items!: TermsHistoryItemDto[];
+}
+
+export class UpdateTermsAgreementItemDto {
+  @IsNumber()
+  @ApiProperty({
+    description: '약관 ID',
+    example: 1,
+  })
+  termId!: number;
+
+  @IsBoolean()
+  @ApiProperty({
+    description: '동의 여부',
+    example: true,
+  })
+  isAccepted!: boolean;
+}
+
+export class UpdateTermsAgreementRequestDto {
+  @IsArray()
+  @ValidateNested({ each: true }) // 배열의 각 요소도 DTO 구조에 맞게 유효성 검사 수행 (글로벌 ValidationPipe({ transform: true })여야 가능)
+  @Type(() => UpdateTermsAgreementItemDto) // 검증을 위해 plain JSON 객체를 DTO 인스턴스로 변환
+  @ApiProperty({
+    description: '업데이트할 약관 동의 정보 배열',
+    type: [UpdateTermsAgreementItemDto],
+  })
+  updates!: UpdateTermsAgreementItemDto[];
+}

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -1,24 +1,122 @@
-import { Controller, Get, Patch } from '@nestjs/common';
+import { Body, Controller, Get, Patch, Post, Query } from '@nestjs/common';
+import {
+  ApiCreatedResponse,
+  ApiHeader,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
 
+// 임시 유저 식별 (JWT 붙기 전까지 mock 헤더 사용)
+import { UserId } from '@common/decorators/user-id-decorator';
+
+import { CreateUserRequestDto, CreateUserResponseDto } from '@modules/users/dto/create-user';
+import { GetMeResponseDto } from '@modules/users/dto/get-me';
+import {
+  CheckNicknameQueryDto,
+  CheckNicknameResponseDto,
+  UpdateNicknameRequestDto,
+  UpdateNicknameResponseDto,
+} from '@modules/users/dto/nickname';
+import {
+  UpdateProfileImageRequestDto,
+  UpdateProfileImageResponseDto,
+} from '@modules/users/dto/profile';
+import {
+  GetTermsHistoryResponseDto,
+  UpdateTermsAgreementRequestDto,
+} from '@modules/users/dto/terms';
+import { UsersService } from '@modules/users/users.service';
+
+@ApiTags('users')
 @Controller('users')
 export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @ApiOperation({ summary: '사용자 생성' })
+  @ApiCreatedResponse({ type: CreateUserResponseDto })
+  @Post()
+  createUser(@Body() dto: CreateUserRequestDto): Promise<CreateUserResponseDto> {
+    return this.usersService.createUser(dto);
+  }
+
+  @ApiOperation({ summary: '내 정보 조회' })
+  @ApiOkResponse({ type: GetMeResponseDto })
+  @ApiHeader({
+    name: 'x-mock-user-id',
+    description: '개발용 사용자 ID (JWT 도입 전 임시)',
+    required: false,
+    schema: { type: 'string', example: '1' },
+  })
   @Get('me')
-  getUserInfo() {
-    return { message: '사용자 정보 조회 (GET /users/me)' };
+  getUserInfo(@UserId() userId: bigint): Promise<GetMeResponseDto> {
+    return this.usersService.getUserInfo(userId);
   }
 
+  @ApiOperation({ summary: '닉네임 사용 가능 여부 확인(디바운스용)' })
+  @ApiOkResponse({ type: CheckNicknameResponseDto })
+  @Get('nickname/check')
+  checkNickname(@Query() q: CheckNicknameQueryDto): Promise<CheckNicknameResponseDto> {
+    return this.usersService.checkNicknameAvailability(q.nickname);
+  }
+
+  @ApiOperation({ summary: '내 정보 - 닉네임 수정' })
+  @ApiOkResponse({ type: UpdateNicknameResponseDto })
+  @ApiHeader({
+    name: 'x-mock-user-id',
+    description: '개발용 사용자 ID (JWT 도입 전 임시)',
+    required: false,
+    schema: { type: 'string', example: '1' },
+  })
+  @Patch('me/nickname')
+  updateNickname(
+    @UserId() userId: bigint,
+    @Body() body: UpdateNicknameRequestDto,
+  ): Promise<UpdateNicknameResponseDto> {
+    return this.usersService.updateNickname(userId, body);
+  }
+
+  @ApiOperation({ summary: '내 정보 - 프로필 이미지 수정/삭제' })
+  @ApiOkResponse({ type: UpdateProfileImageResponseDto })
+  @ApiHeader({
+    name: 'x-mock-user-id',
+    description: '개발용 사용자 ID (JWT 도입 전 임시)',
+    required: false,
+    schema: { type: 'string', example: '1' },
+  })
+  @Patch('me/profile-image')
+  updateProfileImage(
+    @UserId() userId: bigint,
+    @Body() body: UpdateProfileImageRequestDto,
+  ): Promise<UpdateProfileImageResponseDto> {
+    return this.usersService.updateProfileImage(userId, body);
+  }
+
+  @ApiOperation({ summary: '사용자의 약관 동의 내역 조회' })
+  @ApiOkResponse({ type: GetTermsHistoryResponseDto })
+  @ApiHeader({
+    name: 'x-mock-user-id',
+    description: '개발용 사용자 ID (JWT 도입 전 임시)',
+    required: false,
+    schema: { type: 'string', example: '1' },
+  })
   @Get('terms')
-  getTermsHistory() {
-    return { message: '약관 동의 내역 조회 (GET /users/terms)' };
+  getTermsHistory(@UserId() userId: bigint): Promise<GetTermsHistoryResponseDto> {
+    return this.usersService.getTermsHistory(userId);
   }
 
+  @ApiOperation({ summary: '사용자의 약관 동의 내역 수정' })
+  @ApiOkResponse({
+    schema: { example: { message: '약관 동의 내역이 업데이트되었습니다.' } },
+  })
+  @ApiHeader({
+    name: 'x-mock-user-id',
+    description: '개발용 사용자 ID (JWT 도입 전 임시)',
+    required: false,
+    schema: { type: 'string', example: '1' },
+  })
   @Patch('terms')
-  updateTermsAgreement() {
-    return { message: '약관 동의 내역 수정 (PATCH /users/terms)' };
-  }
-
-  @Get('support/info')
-  getSupportInfo() {
-    return { message: '고객센터 운영 정보 조회 (GET /users/support/info)' };
+  updateTermsAgreement(@UserId() userId: bigint, @Body() body: UpdateTermsAgreementRequestDto) {
+    return this.usersService.updateTermsAgreement(userId, body);
   }
 }

--- a/src/modules/users/users.module.ts
+++ b/src/modules/users/users.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 
-import { UsersController } from './users.controller';
-import { UsersService } from './users.service';
+import { UsersController } from '@modules/users/users.controller';
+import { UsersService } from '@modules/users/users.service';
 
 @Module({
   controllers: [UsersController],

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -7,10 +7,7 @@ import {
 
 import { PrismaService } from '@modules/prisma/prisma.service';
 import { CreateUserRequestDto } from '@modules/users/dto/create-user';
-import {
-  // 컨트롤러에서만 쓰면 import 안 해도 OK
-  UpdateNicknameRequestDto,
-} from '@modules/users/dto/nickname';
+import { UpdateNicknameRequestDto } from '@modules/users/dto/nickname';
 import { UpdateProfileImageRequestDto } from '@modules/users/dto/profile';
 import {
   GetTermsHistoryResponseDto,

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -1,7 +1,17 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 
 import { PrismaService } from '@modules/prisma/prisma.service';
 import { CreateUserRequestDto } from '@modules/users/dto/create-user';
+import {
+  // 컨트롤러에서만 쓰면 import 안 해도 OK
+  UpdateNicknameRequestDto,
+} from '@modules/users/dto/nickname';
+import { UpdateProfileImageRequestDto } from '@modules/users/dto/profile';
 import {
   GetTermsHistoryResponseDto,
   UpdateTermsAgreementRequestDto,
@@ -28,7 +38,7 @@ export class UsersService {
       select: { id: true },
     });
 
-    return { message: '사용자가 생성되었습니다.', id: newUser.id.toString() };
+    return { id: newUser.id.toString() };
   }
 
   /**
@@ -85,6 +95,11 @@ export class UsersService {
    * 약관 동의 상태 업데이트
    */
   async updateTermsAgreement(userId: bigint, body: UpdateTermsAgreementRequestDto) {
+    if (!body.updates || body.updates.length === 0) {
+      // 클라이언트가 잘못된 요청 보냈을 때 400 에러 반환
+      throw new BadRequestException('업데이트할 약관 동의 내역이 없습니다.');
+    }
+
     // 여러 약관 동의 변경을 하나의 트랜잭션으로 처리
     await this.prisma.$transaction(
       body.updates.map(({ termId, isAccepted }) =>
@@ -103,5 +118,77 @@ export class UsersService {
     );
 
     return { message: '약관 동의 내역이 업데이트되었습니다.' };
+  }
+
+  /**
+   * 닉네임 사용 가능 여부 확인
+   * - 중복 존재 시 available=false
+   */
+  async checkNicknameAvailability(nickname: string) {
+    const trimmed = nickname.trim();
+    if (!trimmed) {
+      throw new BadRequestException('닉네임을 입력해 주세요.');
+    }
+
+    const exists = await this.prisma.user.findFirst({
+      where: { nickname: trimmed },
+      select: { id: true },
+    });
+
+    return { available: !exists };
+  }
+
+  /**
+   * 내 닉네임 변경
+   * - 자기 자신 제외 중복 방지
+   * - TODO: Prisma에 @unique 제약 추가해야 함
+   */
+  async updateNickname(userId: bigint, dto: UpdateNicknameRequestDto) {
+    const nickname = dto.nickname.trim();
+
+    const nicknameAlreadyExists = await this.prisma.user.findFirst({
+      where: { nickname, NOT: { id: userId } },
+      select: { id: true },
+    });
+    if (nicknameAlreadyExists) {
+      throw new ConflictException('이미 사용 중인 닉네임입니다.');
+    }
+
+    try {
+      await this.prisma.user.update({
+        where: { id: userId },
+        data: { nickname },
+      });
+    } catch (e: any) {
+      // P2002: Prisma unique constraint violation (중복 닉네임)
+      if (e?.code === 'P2002') {
+        throw new ConflictException('이미 사용 중인 닉네임입니다.');
+      }
+      throw e;
+    }
+
+    return { message: '닉네임이 변경되었습니다.' };
+  }
+
+  /**
+   * 내 프로필 이미지 수정/삭제
+   * - null → 삭제
+   */
+  async updateProfileImage(userId: bigint, dto: UpdateProfileImageRequestDto) {
+    if (!Object.prototype.hasOwnProperty.call(dto, 'profileImage')) {
+      return { message: '변경 사항이 없습니다.' };
+    }
+
+    // null → 삭제, string → trim 후 저장
+    const next = dto.profileImage === null ? null : (dto.profileImage as string).trim();
+
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: { profileImage: next },
+    });
+
+    return {
+      message: next ? '프로필 이미지가 업데이트되었습니다.' : '프로필 이미지가 삭제되었습니다.',
+    };
   }
 }

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -1,15 +1,107 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 
 import { PrismaService } from '@modules/prisma/prisma.service';
 import { CreateUserRequestDto } from '@modules/users/dto/create-user';
+import {
+  GetTermsHistoryResponseDto,
+  UpdateTermsAgreementRequestDto,
+} from '@modules/users/dto/terms';
 
 @Injectable()
 export class UsersService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async createNewUser(user: CreateUserRequestDto) {
-    const newUser = await this.prisma.user.create({ data: user });
+  /**
+   * 사용자 생성
+   */
+  async createUser(user: CreateUserRequestDto) {
+    const newUser = await this.prisma.user.create({
+      data: {
+        name: user.name,
+        nickname: user.nickname,
+        birthdate: new Date(user.birthdate),
+        gender: user.gender ?? null,
+        phoneNumber: user.phoneNumber ?? null,
+        profileImage: user.profileImage ?? null,
+        role: user.role || 'USER',
+      },
+      select: { id: true },
+    });
 
-    return 'User created successfully.';
+    return { message: '사용자가 생성되었습니다.', id: newUser.id.toString() };
+  }
+
+  /**
+   * 내 정보 조회
+   */
+  async getUserInfo(userId: bigint) {
+    const profileOwner = await this.prisma.user.findUnique({
+      where: { id: userId },
+    });
+
+    if (!profileOwner) {
+      throw new NotFoundException('해당 사용자를 찾을 수 없습니다.');
+    }
+
+    return {
+      id: profileOwner.id.toString(),
+      name: profileOwner.name,
+      nickname: profileOwner.nickname,
+      birthdate: profileOwner.birthdate.toISOString().slice(0, 10),
+      gender: profileOwner.gender ?? undefined,
+      phoneNumber: profileOwner.phoneNumber ?? undefined,
+      profileImage: profileOwner.profileImage ?? undefined,
+      role: profileOwner.role,
+      createdAt: profileOwner.createdAt.toISOString(),
+      updatedAt: profileOwner.updatedAt.toISOString(),
+    };
+  }
+
+  /**
+   * 약관 동의 이력 조회
+   */
+  async getTermsHistory(userId: bigint): Promise<GetTermsHistoryResponseDto> {
+    const terms = await this.prisma.term.findMany({
+      include: {
+        userTerm: {
+          where: { userId },
+          select: { isAccepted: true },
+        },
+      },
+      orderBy: { id: 'asc' },
+    });
+
+    return {
+      items: terms.map((term) => ({
+        termId: term.id.toString(),
+        title: term.title,
+        isRequired: term.isRequired,
+        isAccepted: term.userTerm[0]?.isAccepted ?? false,
+      })),
+    };
+  }
+
+  /**
+   * 약관 동의 상태 업데이트
+   */
+  async updateTermsAgreement(userId: bigint, body: UpdateTermsAgreementRequestDto) {
+    // 여러 약관 동의 변경을 하나의 트랜잭션으로 처리
+    await this.prisma.$transaction(
+      body.updates.map(({ termId, isAccepted }) =>
+        // upsert: 있으면 업데이트, 없으면 생성
+        this.prisma.userTerm.upsert({
+          // userId_termId: Prisma가 @@id([userId, termId]) 복합키 기반으로 생성
+          where: { userId_termId: { userId, termId: BigInt(termId) } },
+          create: {
+            userId,
+            termId: BigInt(termId),
+            isAccepted,
+          },
+          update: { isAccepted },
+        }),
+      ),
+    );
+
+    return { message: '약관 동의 내역이 업데이트되었습니다.' };
   }
 }


### PR DESCRIPTION
## #️⃣ Related Issues

- resolves #18 

## 🧑‍💻 작업 내용 및 결과
- Users 도메인 API 구현
  - GET /users/me : 내 정보 조회 (BigInt → string 직렬화)
  - GET /users/nickname/check : 닉네임 사용 가능 여부 확인(디바운스용)
  - PATCH /users/me/nickname : 내 닉네임 수정 (중복 방지, P2002 대응)
  - PATCH /users/me/profile-image : 프로필 이미지 수정/삭제(null 시 삭제)
  - GET /users/terms : 약관 동의 이력 조회
  - PATCH /users/terms : 약관 동의 상태 일괄 업데이트(트랜잭션 + upsert)
- @UserId 커스텀 파라미터 데코레이터 추가
  - 현재는 헤더 `x-mock-user-id` → BigInt 변환
  - 추후 Auth(JWT) 도입 시 `req.user.id`로 내부만 교체 예정
- UsersController, UsersService 연결 및 Swagger 문서화
- UsersModule 생성 및 AppModule에 등록
- import 경로 alias(@modules/…)로 정리

## 💬 리뷰 시 요청사항 (선택)

> Reviewer는 코드 리뷰의 코멘트에 코멘트를 강조하고 싶은 정도를 [Pn 규칙](https://blog.banksalad.com/tech/banksalad-code-review-culture/#%EC%BB%A4%EB%AE%A4%EB%8B%88%EC%BC%80%EC%9D%B4%EC%85%98-%EB%B9%84%EC%9A%A9%EC%9D%84-%EC%A4%84%EC%9D%B4%EA%B8%B0-%EC%9C%84%ED%95%9C-pn-%EB%A3%B0)에
> 맞춰서 표기해 주세요.

-

## 📝 Checklist

- [x] Reviewer를 추가했나요?
- [x] Convention을 준수했나요?

---
⚠️ 이 PR은 레포지토리 초기화로 인해 기존 PR(#31 )을 복구하기 위해 다시 생성한 것입니다.
기존 변경사항과 동일합니다.