### PR TITLE
[Feat] 탈퇴 사용자 로그인 및 인증 API 접근 차단 처리

### DIFF
--- a/src/modules/auth/services/auth.service.ts
+++ b/src/modules/auth/services/auth.service.ts
@@ -12,6 +12,7 @@ import { RefreshJwtConfig } from '@modules/auth/config/refresh-jwt.config';
 import { RegisterJwtConfig } from '@modules/auth/config/register-jwt.config';
 import { JwtPayload, RegisterJwtPayload } from '@modules/auth/types/jwt.types';
 import { FrontEnvironment } from '@modules/auth/types/oauth.types';
+import { PrismaService } from '@modules/prisma/prisma.service';
 import { UsersService } from '@modules/users/services/users.service';
 import { OAuthLoginOrRegisterResult } from '@modules/users/types/oauth.users.types';
 
@@ -26,6 +27,7 @@ export class AuthService {
     private readonly userService: UsersService,
     @Inject(FrontendUrlConfig.KEY)
     private readonly frontendUrlConfig: ConfigType<typeof FrontendUrlConfig>,
+    private readonly prisma: PrismaService,
   ) {}
 
   getFrontendOAuthCallbackUrl(frontEnv: FrontEnvironment): string {
@@ -71,10 +73,24 @@ export class AuthService {
    * JWT Guard에서 사용합니다. JWT payload 내의 userId를 받아서 사용자 정보를 반환합니다.
    * @param userId
    */
+  // getUserInfo 사용 시 Auth - User간 순환 참조 문제가 발생하여 직접 prisma 접근으로 변경
   async validateJwtUser(userId: bigint) {
-    const user = await this.userService.getUserInfo(userId);
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        name: true,
+        nickname: true,
+        deletedAt: true,
+        isActive: true,
+      },
+    });
 
     if (!user) throw new UnauthorizedException('INVALID_TOKEN : 존재하지 않는 사용자입니다.');
+
+    if (user.deletedAt || user.isActive === false) {
+      throw new UnauthorizedException('WITHDRAWN_USER : 탈퇴한 사용자입니다.');
+    }
 
     return {
       userId: user.id,

--- a/src/modules/users/services/oauth.users.service.ts
+++ b/src/modules/users/services/oauth.users.service.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import { UnauthorizedException } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
 
 import { Prisma } from '@peekle/prisma/client';
@@ -37,6 +38,10 @@ export class OAuthUserService {
     console.log('OAuthUserService ~ user:', user);
 
     if (user) {
+      if (user.deletedAt || user.isActive === false) {
+        throw new UnauthorizedException('WITHDRAWN_USER : 탈퇴한 사용자입니다.');
+      }
+
       const tokens = await this.authService.generateTokens(user.id);
       return { type: 'login', oauthProvider: oauthData.oauthProvider, tokens };
     } else {

--- a/src/modules/users/services/oauth.users.service.ts
+++ b/src/modules/users/services/oauth.users.service.ts
@@ -1,5 +1,4 @@
-import { BadRequestException, Inject, Injectable } from '@nestjs/common';
-import { UnauthorizedException } from '@nestjs/common';
+import { BadRequestException, Inject, Injectable, UnauthorizedException } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
 
 import { Prisma } from '@peekle/prisma/client';


### PR DESCRIPTION
## #️⃣ Related Issues

- resolves #135, #143

## 🧑‍💻 작업 내용 및 결과

> 어떤 작업을 진행했는지 자세하게 작성해주세요.  
> 사진을 첨부하셔도 좋습니다.

- 탈퇴 사용자 인증 차단 로직 추가 (JWT)
  - JwtStrategy → AuthService.validateJwtUser() 단계에서 DB 조회로 deletedAt / isActive를 확인하고, 탈퇴 사용자면 401 Unauthorized로 차단하여 기존 발급 JWT로도 보호 API 접근이 불가능하도록 처리했습니다.
- 탈퇴 사용자 재로그인 차단 로직 추가 (OAuth)
  - OAuthUserService.oauthLoginOrRegister()에서 기존 사용자 조회 후 deletedAt / isActive 체크를 추가해, 탈퇴 사용자면 토큰 발급 전 401 Unauthorized로 차단했습니다.
- 테스트 항목
  - [x] 정상 사용자 OAuth 로그인 → 정상 리다이렉트 및 토큰 발급 확인
  - [x] 정상 사용자 탈퇴 처리 → DB deletedAt, isActive 값 변경 확인   
  - [x] 탈퇴 사용자 OAuth 재로그인 시도 → 401 Unauthorized 응답 확인
  - [x] 탈퇴 사용자 기존 JWT로 보호 API 호출 → 접근 차단 확인
  - [x] @Public API 호출 → 탈퇴 여부와 관계없이 정상 응답 확인
- 탈퇴한 사용자가 로그인 요청 시 아래와 같은 응답을 뱉습니다.
<img width="595" height="190" alt="image" src="https://github.com/user-attachments/assets/26dfc581-11e9-44e5-8085-9da4caefce81" />



## 💬 리뷰 시 요청사항

- [P3] AuthService에서 prisma 직접 접근으로 순환참조를 회피한 방식이 괜찮은지 의견 부탁드립니다.

## 📝 Checklist

- [x] Reviewer를 추가했나요?
- [x] Convention을 준수했나요?
