### PR TITLE
[Fix] Presigned URL 요청 시 profile domain 미지원으로 업로드 실패

### DIFF
--- a/src/modules/aws/dto/get-presigned-url.dto.ts
+++ b/src/modules/aws/dto/get-presigned-url.dto.ts
@@ -5,6 +5,7 @@ import { IsEnum, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
 export enum UploadDomain {
   EVENTS = 'events',
   COMMUNITY = 'community',
+  PROFILE = 'profile',
 }
 
 export enum UploadKind {

--- a/src/modules/aws/types/aws.types.ts
+++ b/src/modules/aws/types/aws.types.ts
@@ -1,2 +1,2 @@
-export type AwsUploadDomain = 'events' | 'community';
+export type AwsUploadDomain = 'events' | 'community' | 'profile';
 export type AwsUploadFileType = 'image' | 'video';


### PR DESCRIPTION
## #️⃣ Related Issues

- resolves #145 

## 🧑‍💻 작업 내용 및 결과

- S3 Presigned URL 발급 시 profile 도메인을 신규 지원하도록 확장
- DTO(GetPresignedUrlDto) 및 도메인 enum에 profile 값 추가

- `profile` domain으로 요청한 경우
<img width="1395" height="441" alt="image" src="https://github.com/user-attachments/assets/cfda9818-9d8f-4785-abd3-5344c7d5f6d8" />
 

- 없는 domain으로 요청한 경우
<img width="1402" height="206" alt="image" src="https://github.com/user-attachments/assets/5b6c8522-f3b6-42b4-ba77-0a7635516ca4" />


## 💬 리뷰 시 요청사항 (선택)

- 없습니다.

## 📝 Checklist

- [x] Reviewer를 추가했나요?
- [x] Convention을 준수했나요?
