### PR TITLE
[Feat] 탈퇴 계정 로그인 시 OAuth callback에 에러 코드 포함하여 리다이렉트

### DIFF
--- a/src/modules/auth/services/auth.service.ts
+++ b/src/modules/auth/services/auth.service.ts
@@ -106,13 +106,20 @@ export class AuthService {
   ) {
     const redirectUrl = frontendUrl ?? this.getFrontendOAuthCallbackUrl(frontEnv);
 
-    let res: string;
+    // login/register/error 는 서로 순서가 있는 조건이 아니기 때문에 하나의 if-else 흐름으로 묶지 않고,
+    // 각 타입을 조건에 맞는 즉시 return 하는 방식으로 수정해보았습니다.
     if (result.type === 'login') {
-      res = `${redirectUrl}?type=login&oauthProvider=${result.oauthProvider}&accessToken=${result.tokens.accessToken}&refreshToken=${result.tokens.refreshToken}`;
-    } else if (result.type === 'register') {
-      res = `${redirectUrl}?type=register&oauthProvider=${result.oauthProvider}&registerToken=${result.tokens.registerToken}`;
-    } else throw new InternalServerErrorException('Something Got Wrong.');
+      return `${redirectUrl}?type=login&oauthProvider=${result.oauthProvider}&accessToken=${result.tokens.accessToken}&refreshToken=${result.tokens.refreshToken}`;
+    }
 
-    return res;
+    if (result.type === 'register') {
+      return `${redirectUrl}?type=register&oauthProvider=${result.oauthProvider}&registerToken=${result.tokens.registerToken}`;
+    }
+
+    if (result.type === 'error') {
+      return `${redirectUrl}?type=error&oauthProvider=${result.oauthProvider}&errorCode=${result.errorCode}`;
+    }
+
+    throw new InternalServerErrorException('Invalid OAuth result type'); // Something Got Wrong
   }
 }

--- a/src/modules/users/services/oauth.users.service.ts
+++ b/src/modules/users/services/oauth.users.service.ts
@@ -37,8 +37,13 @@ export class OAuthUserService {
     console.log('OAuthUserService ~ user:', user);
 
     if (user) {
+      // 탈퇴한 사용자가 있을 때 프론트에 넘기기 위해 throw 대신 return으로 변경
       if (user.deletedAt || user.isActive === false) {
-        throw new UnauthorizedException('WITHDRAWN_USER : 탈퇴한 사용자입니다.');
+        return {
+          type: 'error',
+          oauthProvider,
+          errorCode: 'USER_WITHDRAWN',
+        };
       }
 
       const tokens = await this.authService.generateTokens(user.id);

--- a/src/modules/users/types/oauth.users.types.ts
+++ b/src/modules/users/types/oauth.users.types.ts
@@ -37,4 +37,10 @@ export interface OAuthRegisterResult {
   };
 }
 
-export type OAuthLoginOrRegisterResult = OAuthLoginResult | OAuthRegisterResult;
+export interface OAuthErrorResult {
+  type: 'error';
+  oauthProvider: OAuthProvider;
+  errorCode: 'USER_WITHDRAWN'; // 탈퇴한 사용자
+}
+
+export type OAuthLoginOrRegisterResult = OAuthLoginResult | OAuthRegisterResult | OAuthErrorResult;


### PR DESCRIPTION
## #️⃣ Related Issues

- resolves #147 

## 🧑‍💻 작업 내용 및 결과

- OAuth 로그인 시 백엔드에서 탈퇴 사용자 여부를 판단하도록 로직 수정
- 탈퇴한 사용자가 로그인 시도한 경우, 예외를 throw하지 않고 OAuth callback redirect URL에 `type=error` 및 `errorCode=USER_WITHDRAWN`를 포함하여 전달

## 💬 리뷰 시 요청사항 (선택)

- [P3] OAuth 로그인 흐름에서 에러 처리를 redirect 기반으로 변경한 방식에 대한 전반적인 구조 리뷰 요청
- [P3] 탈퇴 사용자 분기 시, 이후 로직을 진행하지 않고 즉시 결과를 반환하도록 구조를 단순화한 부분에 대한 리뷰 요청 (`src/modules/auth/services/auth.service.ts`의 if-else if → if)

## 📝 Checklist

- [x] Reviewer를 추가했나요?
- [x] Convention을 준수했나요?
