### PR TITLE
[Feat] 이벤트 목록 다중 카테고리 필터 조회 오류 수정 & [Fix] 거리순 정렬에서 커서 기반 페이징이 정상 동작하지 않는 문제

### DIFF
--- a/src/modules/events/dto/get-events.dto.ts
+++ b/src/modules/events/dto/get-events.dto.ts
@@ -56,6 +56,16 @@ export class GetEventsQueryDto {
   @TransformToBigint()
   cursor?: bigint;
 
+  @ApiPropertyOptional({
+    description: '거리순 정렬용 커서: 마지막으로 본 이벤트와의 거리',
+    example: 1500,
+    type: Number,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  distanceCursor?: number;
+
   // 기간 필터
   @ApiPropertyOptional({ description: '시작일 (YYYY-MM-DD)', example: '2025-09-01' })
   @IsOptional()

--- a/src/modules/events/services/events.query.service.ts
+++ b/src/modules/events/services/events.query.service.ts
@@ -172,7 +172,7 @@ export class EventsQueryService {
           Prisma.sql`e.longitude IS NOT NULL`,
         ];
 
-        // ⭐ 거리 커서 조건
+        // 거리 커서 조건
         if (cursorId !== null && cursorDistance !== null) {
           conditions.push(
             Prisma.sql`(

--- a/src/modules/events/services/events.query.service.ts
+++ b/src/modules/events/services/events.query.service.ts
@@ -153,45 +153,41 @@ export class EventsQueryService {
         const lat = query.latitude;
         const lng = query.longitude;
 
+        let cursorId: bigint | null = null;
         let cursorDistance: number | null = null;
 
-        // cursor 기준 distance 조회
-        if (query.cursor) {
-          let cursorId: bigint;
+        if (query.cursor && query.distanceCursor != null) {
           try {
             cursorId = BigInt(query.cursor);
+            cursorDistance = query.distanceCursor;
           } catch {
-            throw new BadRequestException('cursor는 BigInt 타입이어야 합니다.');
+            throw new BadRequestException('유효하지 않은 cursor 값입니다.');
           }
-
-          const cursorRow = await this.prisma.$queryRaw<Array<{ distance: number }>>`
-    SELECT ST_Distance_Sphere(
-             POINT(${lng}, ${lat}),
-             POINT(e.longitude, e.latitude)
-           ) AS distance
-    FROM event e
-    WHERE e.id = ${cursorId}
-      AND e.latitude IS NOT NULL
-      AND e.longitude IS NOT NULL
-  `;
-
-          if (!cursorRow.length) {
-            throw new BadRequestException('유효하지 않은 cursor입니다.');
-          }
-          cursorDistance = cursorRow[0].distance;
         }
 
         const comparator = sortOrder === 'asc' ? Prisma.sql`>` : Prisma.sql`<`;
 
-        // --- 조건 누적 ---
         const conditions: Prisma.Sql[] = [
           Prisma.sql`e.latitude IS NOT NULL`,
           Prisma.sql`e.longitude IS NOT NULL`,
         ];
 
-        if (cursorDistance !== null) {
+        // ⭐ 거리 커서 조건
+        if (cursorId !== null && cursorDistance !== null) {
           conditions.push(
-            Prisma.sql`ST_Distance_Sphere(POINT(${lng}, ${lat}), POINT(e.longitude, e.latitude)) ${comparator} ${cursorDistance}`,
+            Prisma.sql`(
+      ST_Distance_Sphere(
+        POINT(${lng}, ${lat}),
+        POINT(e.longitude, e.latitude)
+      ) ${comparator} ${cursorDistance}
+      OR (
+        ST_Distance_Sphere(
+          POINT(${lng}, ${lat}),
+          POINT(e.longitude, e.latitude)
+        ) = ${cursorDistance}
+        AND e.id ${comparator} ${cursorId}
+      )
+    )`,
           );
         }
 

--- a/src/modules/events/services/events.query.service.ts
+++ b/src/modules/events/services/events.query.service.ts
@@ -10,10 +10,16 @@ import { PrismaService } from '@modules/prisma/prisma.service';
 export class EventsQueryService {
   constructor(private readonly prisma: PrismaService) {}
 
+  // 이벤트 목록 조회 API
+  // - 필터(query) 기반으로 이벤트를 조회
+  // - 정렬 기준(DATE / PRICE / DISTANCE)에 따라 쿼리 분기
+  // - 커서 기반 페이징 처리
+  // - 로그인 사용자일 경우 찜 여부 계산
+  // - 썸네일 + 응답 DTO로 가공
   async getEventsList(query: GetEventsQueryDto, userId?: bigint) {
     const sortOrder: 'asc' | 'desc' = query.order === Order.ASC ? 'asc' : 'desc';
 
-    // where 절: Prisma용 필터 조건
+    // where 절: Prisma용 필터 조건: 모든 조건은 AND로 묶임
     const andConds: Prisma.EventWhereInput[] = [];
 
     // 내가 찜한 이벤트만 보기
@@ -58,9 +64,13 @@ export class EventsQueryService {
       else andConds.push({ price: { not: 0 } });
     }
 
-    // 카테고리 필터
+    // 카테고리 필터 (OR 조건)
     if (query.categories?.length) {
-      andConds.push({ category: { in: query.categories } });
+      andConds.push({
+        OR: query.categories.map((category) => ({
+          category,
+        })),
+      });
     }
 
     // 검색어 필터 (제목 기준 검색)
@@ -131,6 +141,8 @@ export class EventsQueryService {
         break;
       }
 
+      // 거리순 정렬
+      // 여기서는 Raw SQL로 해야 해서 별도 처리
       case EventSortField.DISTANCE: {
         if (query.latitude == null || query.longitude == null) {
           throw new BadRequestException(
@@ -201,9 +213,11 @@ export class EventsQueryService {
           else conditions.push(Prisma.sql`e.price <> 0`);
         }
 
-        // 카테고리 필터
+        // 카테고리 필터 (OR 조건)
         if (query.categories?.length) {
-          conditions.push(Prisma.sql`e.category IN (${Prisma.join(query.categories)})`);
+          const categoryOr = query.categories.map((c) => Prisma.sql`e.category = ${c}`);
+
+          conditions.push(Prisma.sql`(${Prisma.join(categoryOr, ' OR ')})`);
         }
 
         // 위치 키워드 필터


### PR DESCRIPTION
## #️⃣ Related Issues

- resolves #151
- resolves #152

## 🧑‍💻 작업 내용 및 결과

- 이벤트 목록 다중 카테고리 필터 조회 오류 수정
- 기존 AND처럼 동작하던 필터를 OR 조건으로 동작하도록 개선하여, 선택한 카테고리 중 하나라도 해당되면 조회되도록 변경
- 거리순 정렬 커서 기반 페이징 개선
- 거리순 정렬은 distance 값이 함께 정렬 기준이므로, 다음 페이지 요청 시 cursor(id) + distanceCursor 조합으로 커서를 사용하도록 변경
- 동일한 distance(거리) 값이 여러 개일 수 있어, tie-breaker로 id를 함께 사용해 페이징 누락/중복을 방지


## ✅ 거리순 정렬 커서 사용 방법
- 첫 요청(커서 없음)
  - sort=DISTANCE, latitude, longitude만 전달
  - 응답으로 내려온 `nextCursor`, `nextCursorDistance`를 저장
- 다음 페이지 요청
  - `cursor` = `nextCursor` (마지막으로 받은 이벤트 id)
  - `distanceCursor` = `nextCursorDistance` (그 이벤트의 정확한 distance 값, 소수 부분까지)
  - 즉, distanceCursor는 “cursor로 지정한 이벤트의 거리값”이며 거리순 정렬에서만 사용합니다.


## 💬 리뷰 시 요청사항 (선택)


## 📝 Checklist

- [x] Reviewer를 추가했나요?
- [x] Convention을 준수했나요?
