### PR TITLE
[Feat] 탈퇴 사용자 OAuth 콜백에 계정 삭제일 / 재가입 가능일 전달

### DIFF
--- a/src/modules/auth/services/auth.service.ts
+++ b/src/modules/auth/services/auth.service.ts
@@ -117,7 +117,16 @@ export class AuthService {
     }
 
     if (result.type === 'error') {
-      return `${redirectUrl}?type=error&oauthProvider=${result.oauthProvider}&errorCode=${result.errorCode}`;
+      const deletedAt = result.deletedAt ?? '';
+      const rejoinableAt = result.rejoinableAt ?? '';
+
+      return (
+        `${redirectUrl}?type=error` +
+        `&oauthProvider=${result.oauthProvider}` +
+        `&errorCode=${result.errorCode}` +
+        `&deletedAt=${deletedAt}` +
+        `&rejoinableAt=${rejoinableAt}`
+      );
     }
 
     throw new InternalServerErrorException('Invalid OAuth result type'); // Something Got Wrong

--- a/src/modules/users/services/oauth.users.service.ts
+++ b/src/modules/users/services/oauth.users.service.ts
@@ -34,15 +34,30 @@ export class OAuthUserService {
       },
     });
 
+    const formatDate = (date: Date) => date.toISOString().slice(0, 10); // YYYY-MM-DD
+
     console.log('OAuthUserService ~ user:', user);
 
     if (user) {
       // 탈퇴한 사용자가 있을 때 프론트에 넘기기 위해 throw 대신 return으로 변경
       if (user.deletedAt || user.isActive === false) {
+        if (!user.deletedAt) {
+          // 논리적으로 탈퇴인데 deletedAt이 없는 경우 방어
+          throw new Error('Withdrawn user without deletedAt');
+        }
+
+        const REJOIN_DAYS = 7;
+        const deletedAt = user.deletedAt;
+
+        const rejoinableAt = new Date(deletedAt);
+        rejoinableAt.setDate(rejoinableAt.getDate() + REJOIN_DAYS);
+
         return {
           type: 'error',
           oauthProvider,
           errorCode: 'USER_WITHDRAWN',
+          deletedAt: formatDate(deletedAt),
+          rejoinableAt: formatDate(rejoinableAt),
         };
       }
 

--- a/src/modules/users/types/oauth.users.types.ts
+++ b/src/modules/users/types/oauth.users.types.ts
@@ -41,6 +41,8 @@ export interface OAuthErrorResult {
   type: 'error';
   oauthProvider: OAuthProvider;
   errorCode: 'USER_WITHDRAWN'; // 탈퇴한 사용자
+  deletedAt: string;
+  rejoinableAt: string;
 }
 
 export type OAuthLoginOrRegisterResult = OAuthLoginResult | OAuthRegisterResult | OAuthErrorResult;


### PR DESCRIPTION
## #️⃣ Related Issues

- resolves #155 

## 🧑‍💻 작업 내용 및 결과

<img width="1189" height="207" alt="image" src="https://github.com/user-attachments/assets/60520884-62f2-467f-9319-e8b7ea046907" />
- 탈퇴 계정인 경우 deletedAt, rejoinableAt 정보를 함께 계산하여 전달
- 날짜 값은 프론트에서 바로 사용 가능하도록 YYYY-MM-DD 형식으로 변환
- OAuth callback redirect URL에 탈퇴 관련 정보(errorCode, deletedAt, rejoinableAt)를 쿼리로 포함

## 💬 리뷰 시 요청사항
- [P2] OAuth 에러 응답 구조 및 redirect URL 파라미터 구성 방식 위주로 리뷰 부탁드립니다.

## 📝 Checklist

- [x] Reviewer를 추가했나요?
- [x] Convention을 준수했나요?
