### PR TITLE
[Feat] 탈퇴 후 7일 경과 사용자 계정 데이터 영구 삭제 처리

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@nestjs/mapped-types": "^2.1.0",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.1.6",
+    "@nestjs/schedule": "^6.1.1",
     "@nestjs/swagger": "^11.2.0",
     "@prisma/client": "6.13.0",
     "axios": "^1.11.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@nestjs/platform-express':
         specifier: ^11.1.6
         version: 11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6)
+      '@nestjs/schedule':
+        specifier: ^6.1.1
+        version: 6.1.1(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6)
       '@nestjs/swagger':
         specifier: ^11.2.0
         version: 11.2.0(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6)(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)
@@ -1067,6 +1070,12 @@ packages:
       '@nestjs/common': ^11.0.0
       '@nestjs/core': ^11.0.0
 
+  '@nestjs/schedule@6.1.1':
+    resolution: {integrity: sha512-kQl1RRgi02GJ0uaUGCrXHCcwISsCsJDciCKe38ykJZgnAeeoeVWs8luWtBo4AqAAXm4nS5K8RlV0smHUJ4+2FA==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^10.0.0 || ^11.0.0
+
   '@nestjs/schematics@11.0.7':
     resolution: {integrity: sha512-t8dNYYMwEeEsrlwc2jbkfwCfXczq4AeNEgx1KVQuJ6wYibXk0ZbXbPdfp8scnEAaQv1grpncNV5gWgzi7ZwbvQ==}
     peerDependencies:
@@ -1586,6 +1595,9 @@ packages:
 
   '@types/jsonwebtoken@9.0.7':
     resolution: {integrity: sha512-ugo316mmTYBl2g81zDFnZ7cfxlut3o+/EQdaP7J8QN2kY6lJ22hmQYCK5EHcJHbrW+dkCGSCPgbG8JtYj6qSrg==}
+
+  '@types/luxon@3.7.1':
+    resolution: {integrity: sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==}
 
   '@types/methods@1.1.4':
     resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
@@ -2265,6 +2277,10 @@ packages:
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
+  cron@4.4.0:
+    resolution: {integrity: sha512-fkdfq+b+AHI4cKdhZlppHveI/mgz2qpiYxcm+t5E5TsxX7QrLS1VE0+7GENEk9z0EeGPcpSciGv6ez24duWhwQ==}
+    engines: {node: '>=18.x'}
 
   cross-env@10.0.0:
     resolution: {integrity: sha512-aU8qlEK/nHYtVuN4p7UQgAwVljzMg8hB4YK5ThRqD2l/ziSnryncPNn7bMLt5cFYsKVKBh8HqLqyCoTupEUu7Q==}
@@ -3349,6 +3365,10 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  luxon@3.7.2:
+    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
+    engines: {node: '>=12'}
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
@@ -5779,6 +5799,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@nestjs/schedule@6.1.1(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6)':
+    dependencies:
+      '@nestjs/common': 11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.6)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      cron: 4.4.0
+
   '@nestjs/schematics@11.0.7(chokidar@4.0.3)(typescript@5.8.3)':
     dependencies:
       '@angular-devkit/core': 19.2.15(chokidar@4.0.3)
@@ -6432,6 +6458,8 @@ snapshots:
   '@types/jsonwebtoken@9.0.7':
     dependencies:
       '@types/node': 22.18.1
+
+  '@types/luxon@3.7.1': {}
 
   '@types/methods@1.1.4': {}
 
@@ -7250,6 +7278,11 @@ snapshots:
       - ts-node
 
   create-require@1.1.1: {}
+
+  cron@4.4.0:
+    dependencies:
+      '@types/luxon': 3.7.1
+      luxon: 3.7.2
 
   cross-env@10.0.0:
     dependencies:
@@ -8534,6 +8567,8 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  luxon@3.7.2: {}
 
   magic-string@0.30.17:
     dependencies:

--- a/src/modules/app/app.module.ts
+++ b/src/modules/app/app.module.ts
@@ -1,6 +1,7 @@
 import { MiddlewareConsumer, Module, NestModule, ValidationPipe } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { APP_FILTER, APP_INTERCEPTOR, APP_PIPE } from '@nestjs/core';
+import { ScheduleModule } from '@nestjs/schedule';
 
 import cookieParser from 'cookie-parser';
 import { WinstonModule } from 'nest-winston';
@@ -51,6 +52,7 @@ const validate = (config: Record<string, unknown>) => {
       validate,
     }),
     WinstonModule.forRoot(winstonLoggerOptions),
+    ScheduleModule.forRoot(),
     UsersModule,
     PrismaModule,
     AuthModule,

--- a/src/modules/users/services/user-cleanup.service.ts
+++ b/src/modules/users/services/user-cleanup.service.ts
@@ -2,12 +2,19 @@ import { Injectable, Logger } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 
 import dayjs from 'dayjs';
+import timezone from 'dayjs/plugin/timezone';
+import utc from 'dayjs/plugin/utc';
 
 import { PrismaService } from '@modules/prisma/prisma.service';
+
+// dayjs timezone 플러그인 활성화
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 @Injectable()
 export class UserCleanupService {
   private readonly logger = new Logger(UserCleanupService.name);
+  private readonly BATCH_SIZE = 100; // 배치당 삭제할 최대 사용자 수
 
   constructor(private readonly prisma: PrismaService) {}
 
@@ -23,20 +30,56 @@ export class UserCleanupService {
     this.logger.log('탈퇴 사용자 정리 작업 시작');
 
     try {
-      // 7일 전 날짜 계산
-      const sevenDaysAgo = dayjs().subtract(7, 'day').toDate();
+      // P2: Asia/Seoul 기준으로 7일 전 날짜 계산
+      const sevenDaysAgo = dayjs().tz('Asia/Seoul').subtract(7, 'day').toDate();
 
-      // deletedAt이 7일 이전이고 isActive가 false인 사용자 삭제
-      const result = await this.prisma.user.deleteMany({
-        where: {
-          isActive: false,
-          deletedAt: {
-            lte: sevenDaysAgo, // less than or equal (이하)
+      let totalDeletedCount = 0;
+      let batchNumber = 1;
+
+      while (true) {
+        // P3: 배치 단위로 삭제 대상 조회 (id만 조회)
+        const usersToDelete = await this.prisma.user.findMany({
+          where: {
+            isActive: false,
+            deletedAt: {
+              not: null, // P1: NULL 명시적 제외
+              lte: sevenDaysAgo,
+            },
           },
-        },
-      });
+          select: { id: true },
+          take: this.BATCH_SIZE,
+        });
 
-      this.logger.log(`탈퇴 사용자 정리 완료: ${result.count}명의 사용자가 영구 삭제되었습니다.`);
+        // 더 이상 삭제할 사용자가 없으면 종료
+        if (usersToDelete.length === 0) {
+          break;
+        }
+
+        // 조회된 사용자 ID 목록으로 삭제 실행
+        const userIds = usersToDelete.map((user) => user.id);
+        const result = await this.prisma.user.deleteMany({
+          where: {
+            id: { in: userIds },
+          },
+        });
+
+        totalDeletedCount += result.count;
+
+        this.logger.log(
+          `배치 #${batchNumber}: ${result.count}명 삭제 (누적: ${totalDeletedCount}명)`,
+        );
+
+        batchNumber++;
+
+        // 조회된 개수가 BATCH_SIZE보다 적으면 마지막 배치
+        if (usersToDelete.length < this.BATCH_SIZE) {
+          break;
+        }
+      }
+
+      this.logger.log(
+        `탈퇴 사용자 정리 완료: 총 ${totalDeletedCount}명의 사용자가 영구 삭제되었습니다.`,
+      );
     } catch (error) {
       this.logger.error('탈퇴 사용자 정리 중 오류 발생', error);
     }

--- a/src/modules/users/services/user-cleanup.service.ts
+++ b/src/modules/users/services/user-cleanup.service.ts
@@ -1,0 +1,44 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+
+import dayjs from 'dayjs';
+
+import { PrismaService } from '@modules/prisma/prisma.service';
+
+@Injectable()
+export class UserCleanupService {
+  private readonly logger = new Logger(UserCleanupService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * 매일 새벽 4시에 실행
+   * deletedAt 기준 7일이 지난 isActive=false 사용자 영구 삭제
+   */
+  @Cron('0 4 * * *', {
+    name: 'deleteWithdrawnUsers',
+    timeZone: 'Asia/Seoul',
+  })
+  async deleteWithdrawnUsers() {
+    this.logger.log('탈퇴 사용자 정리 작업 시작');
+
+    try {
+      // 7일 전 날짜 계산
+      const sevenDaysAgo = dayjs().subtract(7, 'day').toDate();
+
+      // deletedAt이 7일 이전이고 isActive가 false인 사용자 삭제
+      const result = await this.prisma.user.deleteMany({
+        where: {
+          isActive: false,
+          deletedAt: {
+            lte: sevenDaysAgo, // less than or equal (이하)
+          },
+        },
+      });
+
+      this.logger.log(`탈퇴 사용자 정리 완료: ${result.count}명의 사용자가 영구 삭제되었습니다.`);
+    } catch (error) {
+      this.logger.error('탈퇴 사용자 정리 중 오류 발생', error);
+    }
+  }
+}

--- a/src/modules/users/users.module.ts
+++ b/src/modules/users/users.module.ts
@@ -8,6 +8,7 @@ import { RefreshJwtConfig } from '@modules/auth/config/refresh-jwt.config';
 import { RegisterJwtConfig } from '@modules/auth/config/register-jwt.config';
 import { AuthService } from '@modules/auth/services/auth.service';
 import { OAuthUserService } from '@modules/users/services/oauth.users.service';
+import { UserCleanupService } from '@modules/users/services/user-cleanup.service';
 import { UsersService } from '@modules/users/services/users.service';
 import { UsersController } from '@modules/users/users.controller';
 
@@ -19,7 +20,7 @@ import { UsersController } from '@modules/users/users.controller';
     // ConfigModule.forFeature(FrontendUrlConfig),
   ],
   controllers: [UsersController],
-  providers: [UsersService, OAuthUserService, AuthService],
+  providers: [UsersService, OAuthUserService, AuthService, UserCleanupService],
   exports: [UsersService, OAuthUserService],
 })
 export class UsersModule {}


### PR DESCRIPTION
## #️⃣ Related Issues

- resolves #148
- #135 

## 🧑‍💻 작업 내용 및 결과

- 탈퇴 후 7일이 경과한 사용자 영구 삭제 스케줄러 구현
- NestJS @Cron을 활용하여 매일 새벽 4시(Asia/Seoul) 자동 실행
- 삭제 조건:
  - isActive = false
  - deletedAt <= 현재시각 - 7일
- deleteMany를 사용하여 대상 사용자 일괄 삭제
- 작업 시작/완료 및 예외 상황에 대한 로그 처리 추가


## 💬 리뷰 시 요청사항

- [P2] 스케줄 실행 시간(현재 04:00 KST)이 적절한지 확인 부탁드립니다.
- [P3] 추후 사용자 연관 데이터 정리 방식(Cascade vs 명시적 삭제)에 대한 방향성 논의가 필요할 것 같습니다.

## 📝 Checklist

- [x] Reviewer를 추가했나요?
- [x] Convention을 준수했나요?
